### PR TITLE
Bump Scala 2.13 to support Scala 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
     - CI_HOME=`pwd`
 
 script:
-  - cd $CI_HOME && sbt test
+  - cd $CI_HOME && sbt ++test

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "robotparser-scala"
 organization := "jp.co.bizreach"
 scalaVersion := "2.12.8"
-crossScalaVersions := Seq(scalaVersion.value, "2.13.0")
+crossScalaVersions := Seq(scalaVersion.value, "2.13.6")
 
 libraryDependencies ++= Seq(
   "org.scala-lang.modules"     %% "scala-xml"   % "1.2.0",


### PR DESCRIPTION
Scala 3 can consume artifacts published for Scala 2.13.6.
https://scalacenter.github.io/scala-3-migration-guide/docs/compatibility/classpath.html